### PR TITLE
Fix bug in function `whoFinished()` caused by using the wrong index

### DIFF
--- a/BackEnd.java
+++ b/BackEnd.java
@@ -350,7 +350,7 @@ public class BackEnd {
             return 0;            
         } else if (figures[4].isFinished() && figures[5].isFinished() && figures[6].isFinished() && figures[7].isFinished()) {
             return 1;
-        } else if (figures[9].isFinished() && figures[9].isFinished() && figures[10].isFinished() && figures[11].isFinished()) {
+        } else if (figures[8].isFinished() && figures[9].isFinished() && figures[10].isFinished() && figures[11].isFinished()) {
             return 2;
         } else {
             return 3;


### PR DESCRIPTION
The third player may have only three of four pieces in the house, but is still declared the winner. The fourth player would be passed over in this case, although they might have been the actual winner.