### PR TITLE
Add custom logging handler

### DIFF
--- a/ANSIColorCodes.java
+++ b/ANSIColorCodes.java
@@ -1,0 +1,21 @@
+public enum ANSIColorCodes {
+    RESET("\u001B[0m"),
+    BLACK("\u001B[30m"),
+    RED("\u001B[31m"),
+    GREEN("\u001B[32m"),
+    YELLOW("\u001B[33m"),
+    BLUE("\u001B[34m"),
+    PURPLE("\u001B[35m"),
+    CYAN("\u001B[36m"),
+    WHITE("\u001B[37m");
+
+    private final String code;
+
+    private ANSIColorCodes(String code) {
+	this.code = code;
+    }
+
+    public String getCode() {
+	return code;
+    }
+}

--- a/ConsoleLogger.java
+++ b/ConsoleLogger.java
@@ -6,15 +6,15 @@ public final class ConsoleLogger implements Logger {
     private static DateTimeFormatter formatter;
     private static Level logForLevelEqualOrAbove;
 
-    private ConsoleLogger() {
+    private ConsoleLogger(Level loggingLevel) {
 	formatter = DateTimeFormatter
 	    .ofPattern("yyyy/MM/dd HH:mm:ss.SSS");
-	logForLevelEqualOrAbove = Level.DEBUG;
+	logForLevelEqualOrAbove = loggingLevel;
     }
 
-    public static ConsoleLogger getInstance() {
+    public static ConsoleLogger getInstance(Level loggingLevel) {
 	if (instance == null) {
-	    instance = new ConsoleLogger();
+	    instance = new ConsoleLogger(loggingLevel);
 	}
 	return instance;
     }

--- a/ConsoleLogger.java
+++ b/ConsoleLogger.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 public final class ConsoleLogger implements Logger {
     private static ConsoleLogger instance;
     private static DateTimeFormatter formatter;
-    
+
     private enum Level {
 	DEBUG,
 	INFO,
@@ -25,18 +25,20 @@ public final class ConsoleLogger implements Logger {
     }
 
     public void debug(String message) {
-    	System.out.println(format(Level.DEBUG, message));
+    	System.out.println(ANSIColorCodes.BLUE.getCode()
+			   + format(Level.DEBUG, message)
+			   + ANSIColorCodes.RESET.getCode());
     };
 
     private String format(Level level, String message) {
 	String levelEnclosingStart = "[";
 	String levelEnclosingEnd = "] ";
 	String messageSeparator = ": ";
-	
+    
 	if (Level.INFO == level || Level.WARN == level) {
 	    // Because info and warn levels are one character shorter
-	    // than all other levels, we append a single space to
-	    // align all messages properly.
+	    // than all other levels, we append a single space at the
+	    // start for properly aligning all messages.
 	    levelEnclosingStart = " [";
 	}
 
@@ -45,15 +47,23 @@ public final class ConsoleLogger implements Logger {
     };
     
     public void info(String message) {
-	System.out.println(format(Level.INFO, message));
+	System.out.println(ANSIColorCodes.WHITE.getCode()
+			   + format(Level.INFO, message)
+			   + ANSIColorCodes.RESET.getCode());
     };
     public void warn(String message) {
-	System.out.println(format(Level.WARN, message));
+	System.out.println(ANSIColorCodes.YELLOW.getCode()
+			   + format(Level.WARN, message)
+			   + ANSIColorCodes.RESET.getCode());
     };
     public void error(String message) {
-    	System.out.println(format(Level.ERROR, message));
+    	System.out.println(ANSIColorCodes.PURPLE.getCode()
+			   + format(Level.ERROR, message)
+			   + ANSIColorCodes.RESET.getCode());
     };
     public void fatal(String message) {
-    	System.out.println(format(Level.FATAL, message));
+    	System.out.println(ANSIColorCodes.RED.getCode()
+			   + format(Level.FATAL, message)
+			   + ANSIColorCodes.RESET.getCode());
     };
 }

--- a/ConsoleLogger.java
+++ b/ConsoleLogger.java
@@ -1,0 +1,59 @@
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+
+public final class ConsoleLogger implements Logger {
+    private static ConsoleLogger instance;
+    private static DateTimeFormatter formatter;
+    
+    private enum Level {
+	DEBUG,
+	INFO,
+	WARN,
+	ERROR,
+	FATAL,
+    }
+
+    private ConsoleLogger() {
+	formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss.SSS");
+    }
+
+    public static ConsoleLogger getInstance() {
+	if (instance == null) {
+	    instance = new ConsoleLogger();
+	}
+	return instance;
+    }
+
+    public void debug(String message) {
+    	System.out.println(format(Level.DEBUG, message));
+    };
+
+    private String format(Level level, String message) {
+	String levelEnclosingStart = "[";
+	String levelEnclosingEnd = "] ";
+	String messageSeparator = ": ";
+	
+	if (Level.INFO == level || Level.WARN == level) {
+	    // Because info and warn levels are one character shorter
+	    // than all other levels, we append a single space to
+	    // align all messages properly.
+	    levelEnclosingStart = " [";
+	}
+
+	return levelEnclosingStart + level.toString() + levelEnclosingEnd
+	    + formatter.format(LocalDateTime.now()) + messageSeparator + message;
+    };
+    
+    public void info(String message) {
+	System.out.println(format(Level.INFO, message));
+    };
+    public void warn(String message) {
+	System.out.println(format(Level.WARN, message));
+    };
+    public void error(String message) {
+    	System.out.println(format(Level.ERROR, message));
+    };
+    public void fatal(String message) {
+    	System.out.println(format(Level.FATAL, message));
+    };
+}

--- a/ConsoleLogger.java
+++ b/ConsoleLogger.java
@@ -4,17 +4,12 @@ import java.time.LocalDateTime;
 public final class ConsoleLogger implements Logger {
     private static ConsoleLogger instance;
     private static DateTimeFormatter formatter;
-
-    private enum Level {
-	DEBUG,
-	INFO,
-	WARN,
-	ERROR,
-	FATAL,
-    }
+    private static Level logForLevelEqualOrAbove;
 
     private ConsoleLogger() {
-	formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss.SSS");
+	formatter = DateTimeFormatter
+	    .ofPattern("yyyy/MM/dd HH:mm:ss.SSS");
+	logForLevelEqualOrAbove = Level.DEBUG;
     }
 
     public static ConsoleLogger getInstance() {
@@ -25,10 +20,21 @@ public final class ConsoleLogger implements Logger {
     }
 
     public void debug(String message) {
-    	System.out.println(ANSIColorCodes.BLUE.getCode()
-			   + format(Level.DEBUG, message)
-			   + ANSIColorCodes.RESET.getCode());
+	if (shouldLog(Level.DEBUG)) {
+	    System.out.println(ANSIColorCodes.BLUE.getCode()
+			       + format(Level.DEBUG, message)
+			       + ANSIColorCodes.RESET.getCode());
+	}
     };
+
+    private boolean shouldLog(Level level) {
+	// Only log messages whose level is equal or above the level
+	// specified in the constructor. This allows for example
+	// turning off all message below WARN to only print severe
+	// messages.
+	return logForLevelEqualOrAbove.ordinal() <= level.ordinal();
+    }
+	    
 
     private String format(Level level, String message) {
 	String levelEnclosingStart = "[";
@@ -42,28 +48,40 @@ public final class ConsoleLogger implements Logger {
 	    levelEnclosingStart = " [";
 	}
 
-	return levelEnclosingStart + level.toString() + levelEnclosingEnd
-	    + formatter.format(LocalDateTime.now()) + messageSeparator + message;
+	return levelEnclosingStart
+	    + level.toString()
+	    + levelEnclosingEnd
+	    + formatter.format(LocalDateTime.now())
+	    + messageSeparator
+	    + message;
     };
     
     public void info(String message) {
-	System.out.println(ANSIColorCodes.WHITE.getCode()
-			   + format(Level.INFO, message)
-			   + ANSIColorCodes.RESET.getCode());
+	if (shouldLog(Level.INFO)) {
+	    System.out.println(ANSIColorCodes.WHITE.getCode()
+			       + format(Level.INFO, message)
+			       + ANSIColorCodes.RESET.getCode());
+	}
     };
     public void warn(String message) {
-	System.out.println(ANSIColorCodes.YELLOW.getCode()
-			   + format(Level.WARN, message)
-			   + ANSIColorCodes.RESET.getCode());
+	if (shouldLog(Level.WARN)) {
+	    System.out.println(ANSIColorCodes.YELLOW.getCode()
+			       + format(Level.WARN, message)
+			       + ANSIColorCodes.RESET.getCode());
+	}
     };
     public void error(String message) {
-    	System.out.println(ANSIColorCodes.PURPLE.getCode()
-			   + format(Level.ERROR, message)
-			   + ANSIColorCodes.RESET.getCode());
+    	if (shouldLog(Level.ERROR)) {
+	    System.out.println(ANSIColorCodes.PURPLE.getCode()
+			       + format(Level.ERROR, message)
+			       + ANSIColorCodes.RESET.getCode());
+	}
     };
     public void fatal(String message) {
-    	System.out.println(ANSIColorCodes.RED.getCode()
-			   + format(Level.FATAL, message)
-			   + ANSIColorCodes.RESET.getCode());
+    	if (shouldLog(Level.FATAL)) {
+	    System.out.println(ANSIColorCodes.RED.getCode()
+			       + format(Level.FATAL, message)
+			       + ANSIColorCodes.RESET.getCode());
+	}
     };
 }

--- a/Level.java
+++ b/Level.java
@@ -1,0 +1,7 @@
+public enum Level {
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+    FATAL,
+}

--- a/Logger.java
+++ b/Logger.java
@@ -1,7 +1,7 @@
 interface Logger {
-    public static void debug(String message);
-    public static void info(String message);
-    public static void warn(String message);
-    public static void error(String message);
-    public static void fatal(String message);
+    public void debug(String message);
+    public void info(String message);
+    public void warn(String message);
+    public void error(String message);
+    public void fatal(String message);
 }

--- a/Logger.java
+++ b/Logger.java
@@ -1,0 +1,7 @@
+interface Logger {
+    public static void debug(String message);
+    public static void info(String message);
+    public static void warn(String message);
+    public static void error(String message);
+    public static void fatal(String message);
+}

--- a/LoggerFactory.java
+++ b/LoggerFactory.java
@@ -1,0 +1,5 @@
+public class LoggerFactory {
+    public static Logger getInstance() {
+	return ConsoleLogger.getInstance();
+    }
+}

--- a/LoggerFactory.java
+++ b/LoggerFactory.java
@@ -1,5 +1,7 @@
 public class LoggerFactory {
-    public static Logger getInstance() {
-	return ConsoleLogger.getInstance();
+    private LoggerFactory() {};
+    
+    public static Logger getLoggerInstance() {
+	return ConsoleLogger.getInstance(Level.DEBUG);
     }
 }

--- a/Main.java
+++ b/Main.java
@@ -2,7 +2,7 @@ import javax.swing.*;
 
 public class Main {
     public static void main(String[] args) {
-	Logger logger = ConsoleLogger.getInstance();
+	Logger logger = LoggerFactory.getInstance();
 	logger.info("Starting game.");
 
 	Thread quittingHook = new Thread(() -> logger.info("Quitting game."));

--- a/Main.java
+++ b/Main.java
@@ -2,6 +2,13 @@ import javax.swing.*;
 
 public class Main {
     public static void main(String[] args) {
+	Logger logger = ConsoleLogger.getInstance();
+	logger.debug("Test! 1, 2, 3, Test!");
+	logger.info("Hello World!");
+	logger.warn("Not su good...");
+	logger.error("What was that?");
+	logger.fatal("Aaaaaargghhhh!");
+	
         try {
             // Set the look and feel
             UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());

--- a/Main.java
+++ b/Main.java
@@ -2,7 +2,7 @@ import javax.swing.*;
 
 public class Main {
     public static void main(String[] args) {
-	Logger logger = LoggerFactory.getInstance();
+	Logger logger = LoggerFactory.getLoggerInstance();
 	logger.info("Starting game.");
 
 	Thread quittingHook = new Thread(() -> logger.info("Quitting game."));

--- a/Main.java
+++ b/Main.java
@@ -3,20 +3,23 @@ import javax.swing.*;
 public class Main {
     public static void main(String[] args) {
 	Logger logger = ConsoleLogger.getInstance();
-	logger.debug("Test! 1, 2, 3, Test!");
-	logger.info("Hello World!");
-	logger.warn("Not su good...");
-	logger.error("What was that?");
-	logger.fatal("Aaaaaargghhhh!");
+	logger.info("Starting game.");
+
+	Thread quittingHook = new Thread(() -> logger.info("Quitting game."));
+	Runtime.getRuntime().addShutdownHook(quittingHook);
 	
         try {
-            // Set the look and feel
+	    logger.info("Try setting look and feel of windows.");
             UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
-            new Landingpage();
-
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException e) {
+   
+	    logger.info("Instantiating landingpage.");
+	    new Landingpage();
+        } catch (UnsupportedLookAndFeelException e) {
+	    logger.fatal("Unable to set the look and feel of windows.");
             e.printStackTrace();
-        
-        }
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+	    logger.fatal("An unexpected error occured.");
+	    e.printStackTrace();
+	}
     }
 }


### PR DESCRIPTION
Permanently placing logging statements at critical or important places in the code simplifies debugging, because you always know the current state of the program and the value of specific variables . Access the logger using this piece of code:

```java
Logger logger = new LoggerFactory.getLoggerInstance();

logger.debug("Test! 1, 2, 3, Test!");
logger.info("Hello World!");
logger.warn("That's not good...");
logger.error("What was that!?");
logger.fatal("AAAAAAaaaaarrgghhh!");
```

The logger is a so called [Singleton](https://refactoring.guru/design-patterns/singleton), which ensures that there is exactly one instance of `Logger` throughout the execution. On top of that, the actual implementation of `Logger`, in this case `ConsoleLogger`, is hidden behind another class named `LoggerFactory`. By using `LoggerFactory` as a dependency throughout the code, you can easily swap out `ConsoleLogger` for, say, a `FileLogger` while only having to edit the reference in LoggerFactory.java.

If you would like to disable logging debug messages, info messages or messages of higher levels, go into LoggerFactory.java and edit this line in the `getLoggerInstance()` method:

```java
return ConsoleLogger.getInstance(Level.DEBUG);  // Levels can be DEBUG, INFO, WARN, ERROR or FATAL.
```

The logger will only print log messages for levels equal or above the level passed to `ConsoleLogger`. The output will look similar to this:

![Screenshot from 2023-08-04 14-37-46](https://github.com/MeiNic/MenschAergereDichNicht/assets/93522160/45c165f6-d7b1-4a84-8ebe-e72273aff6b8)
![Screenshot from 2023-08-04 14-38-11](https://github.com/MeiNic/MenschAergereDichNicht/assets/93522160/83232a70-9592-4804-a246-009165967f1e)


PS: I have tested colored output both on GNU/Linux as well as Windows (11), at least for Powershell 7 it works fine, cmd will probably not work as intended, however, I don't think we should support this console.