### PR TITLE
Fix scaling issue for hDPI screens on GNU/Linux

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,11 @@ javac Main.java
 echo "done."
 
 echo "Starting game."
-java Main
+if [[ "$OSTYPE" == "linux-gnu" ]]
+then
+    java -Dsun.java2d.uiScale=2.0 Main
+else
+    java Main
+fi
 
 cd ../


### PR DESCRIPTION
When running the game on GNU/Linux (in my case Pop OS) using an hDPI display, the window is really small (almost not readable). Both on Manjaro Linux using a "normal" 1080p monitor as well as on Windows 11 the window is scaled properly.

Appending a scaling flag to `java` is a quick and dirty fix for this problem, and is, at least in my opinion, a better way than trying to implement a solution in code.

Please note that this will always scale windows when using GNU/Linux as an operating system and does not respect whether the user actually has an hDPI display. I personally won't need this functionality, so I don't care about checking for the screen resolution, but if a developer (and only developers should ever need to use this script) really needs that, they can simply comment the if-statement (or add this feature themself ;-).