### PR TITLE
Fix broken run.sh script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,22 +2,18 @@
 # A small utility for running the game while developing. This script
 # ensures that the program is recompiled completely by removing any
 # .class files before starting javac.
-cd src/
-
 printf "Cleaning up... "
-rm *.class
+rm src/*.class
 echo "done."
 
 printf "Compiling... "
-javac Main.java
+javac src/Main.java
 echo "done."
 
 echo "Starting game."
 if [[ "$OSTYPE" == "linux-gnu" ]]
 then
-    java -Dsun.java2d.uiScale=2.0 Main
+    java -Dsun.java2d.uiScale=2.0 src/Main
 else
-    java Main
+    java src/Main
 fi
-
-cd ../


### PR DESCRIPTION
Adding all files to package `src` (commit a00bee2) caused run.sh to break due to some unresolved dependencies on other classes. It turns out that we need to run both `javac` and `java` from within the root directory, not the `src/` folder to make the script function again.