### PR TITLE
Add spotless code formatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,41 @@
                     </execution>
                 </executions>
             </plugin>
+	    <plugin>
+	        <groupId>com.diffplug.spotless</groupId>
+	        <artifactId>spotless-maven-plugin</artifactId>
+	        <version>2.44.5</version>
+	        <configuration>
+		    <formats>
+		        <format>
+		            <includes>
+		                <include>.gitattributes</include>
+		                <include>.gitignore</include>
+		            </includes>
+		            <trimTrailingWhitespace/>
+		            <endWithNewline/>
+		            <indent>
+		                <tabs>true</tabs>
+		                <spacesPerTab>4</spacesPerTab>
+		            </indent>
+		        </format>
+		    </formats>
+		    <java>
+		        <googleJavaFormat>
+		            <version>1.10.0</version>
+		            <style>AOSP</style>
+		            <reflowLongStrings>true</reflowLongStrings>
+		            <formatJavadoc>false</formatJavadoc>
+		        </googleJavaFormat>
+		        <importOrder />
+		        <removeUnusedImports />
+		        <formatAnnotations />
+		    </java>
+		    <pom>
+                        <sortPom />
+		    </pom>
+	        </configuration>
+	    </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Running `mvn verify` now checks for unsorted imports, wrong whitespace, missing newlines and many more. I will change this to also automatically apply suggested fixes when running `mvn compile` or `mvn test`, but right now, this would fail our CI, so it has to be a separate pull request.