### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MeiNic/MenschAergereDichNicht/security/code-scanning/1](https://github.com/MeiNic/MenschAergereDichNicht/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly limit the GITHUB_TOKEN permissions. The best way to do this is to add the block at the root level of the workflow (just after the `name:` field and before `on:`), so it applies to all jobs unless overridden. The minimal required permission for this workflow is `contents: read`, since the jobs only need to check out code and do not require write access to repository contents, issues, or pull requests. No changes to the steps or jobs are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
